### PR TITLE
Adding count accessor to contourDensity to support binned datasets as input

### DIFF
--- a/src/density.js
+++ b/src/density.js
@@ -12,9 +12,14 @@ function defaultY(d) {
   return d[1];
 }
 
+function defaultCount() {
+  return 1;
+}
+
 export default function() {
   var x = defaultX,
       y = defaultY,
+      count = defaultCount,
       dx = 960,
       dy = 500,
       r = 20, // blur radius
@@ -32,7 +37,7 @@ export default function() {
       var xi = (x(d, i, data) + o) >> k,
           yi = (y(d, i, data) + o) >> k;
       if (xi >= 0 && xi < n && yi >= 0 && yi < m) {
-        ++values0[xi + yi * n];
+        values0[xi + yi * n] += count(d);
       }
     });
 
@@ -94,6 +99,10 @@ export default function() {
 
   density.y = function(_) {
     return arguments.length ? (y = typeof _ === "function" ? _ : constant(+_), density) : y;
+  };
+
+  density.count = function(_) {
+    return arguments.length ? (count = typeof _ === "function" ? _ : constant(+_), density) : count;
   };
 
   density.size = function(_) {


### PR DESCRIPTION
Currently contourDensity can only be applied to a point cloud, not to a dataset which is already binned, like this one:
```
  const counts =[{x:3,y:5,count:2},{x:4,y:2,count:12},{x:4,y:3,count:3}, ... ]
```
This patch enables this by adding an accessor for the counts:
```
  const contours = d3contour
    .contourDensity()
      .count(d => d.count)
      .x(d => xScale(d.x))
      .y(d => yScale(d.y))
      .size([width, height])
      .thresholds(thresholds)
      .bandwidth(bandwidth)(counts)

```