### PR TITLE
Add density weight parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Constructs a new density estimator with the default settings.
 
 Estimates the density contours for the given array of *data*, returning an array of [GeoJSON](http://geojson.org/geojson-spec.html) [MultiPolygon](http://geojson.org/geojson-spec.html#multipolygon) [geometry objects](http://geojson.org/geojson-spec.html#geometry-objects). Each geometry object represents the area where the estimated number of points per square pixel is greater than or equal to the corresponding [threshold value](#density_thresholds); the threshold value for each geometry object is exposed as <i>geometry</i>.value. The returned geometry objects are typically passed to [d3.geoPath](https://github.com/d3/d3-geo/blob/master/README.md#geoPath) to display, using null or [d3.geoIdentity](https://github.com/d3/d3-geo/blob/master/README.md#geoIdentity) as the associated projection. See also [d3.contours](#contours).
 
-The *x*- and *y*-coordinate for each data point are computed using [*density*.x](#density_x) and [*density*.y](#density_y). The generated contours are only accurate within the estimator’s [defined size](#density_size).
+The *x*- and *y*-coordinate for each data point are computed using [*density*.x](#density_x) and [*density*.y](#density_y). In addition, [*density*.weight](#density_weight) indicates the relative contribution of each data point (default 1). The generated contours are only accurate within the estimator’s [defined size](#density_size).
 
 <a name="density_x" href="#density_x">#</a> <i>density</i>.<b>x</b>([<i>x</i>]) [<>](https://github.com/d3/d3-contour/blob/master/src/density.js "Source")
 
@@ -138,6 +138,16 @@ If *y* is specified, sets the *y*-coordinate accessor. If *y* is not specified, 
 ```js
 function y(d) {
   return d[1];
+}
+```
+
+<a name="density_weight" href="#density_weight">#</a> <i>density</i>.<b>weight</b>([<i>weight</i>]) [<>](https://github.com/d3/d3-contour/blob/master/src/density.js "Source")
+
+If *weight* is specified, sets the accessor for point weights. If *weight* is not specified, returns the current point weight accessor, which defaults to:
+
+```js
+function weight() {
+  return 1;
 }
 ```
 

--- a/src/density.js
+++ b/src/density.js
@@ -34,9 +34,9 @@ export default function() {
         values1 = new Float32Array(n * m);
 
     data.forEach(function(d, i, data) {
-      var xi = (x(d, i, data) + o) >> k,
-          yi = (y(d, i, data) + o) >> k,
-          wi = weight(d, i, data);
+      var xi = (+x(d, i, data) + o) >> k,
+          yi = (+y(d, i, data) + o) >> k,
+          wi = +weight(d, i, data);
       if (xi >= 0 && xi < n && yi >= 0 && yi < m) {
         values0[xi + yi * n] += wi;
       }

--- a/src/density.js
+++ b/src/density.js
@@ -12,9 +12,14 @@ function defaultY(d) {
   return d[1];
 }
 
+function defaultWeight() {
+  return 1;
+}
+
 export default function() {
   var x = defaultX,
       y = defaultY,
+      weight = defaultWeight,
       dx = 960,
       dy = 500,
       r = 20, // blur radius
@@ -30,9 +35,10 @@ export default function() {
 
     data.forEach(function(d, i, data) {
       var xi = (x(d, i, data) + o) >> k,
-          yi = (y(d, i, data) + o) >> k;
+          yi = (y(d, i, data) + o) >> k,
+          wi = weight(d, i, data);
       if (xi >= 0 && xi < n && yi >= 0 && yi < m) {
-        ++values0[xi + yi * n];
+        values0[xi + yi * n] += wi;
       }
     });
 
@@ -94,6 +100,10 @@ export default function() {
 
   density.y = function(_) {
     return arguments.length ? (y = typeof _ === "function" ? _ : constant(+_), density) : y;
+  };
+
+  density.weight = function(_) {
+    return arguments.length ? (weight = typeof _ === "function" ? _ : constant(+_), density) : weight;
   };
 
   density.size = function(_) {


### PR DESCRIPTION
Adds a _weight_ parameter (default 1) to enable density estimation for pre-aggregated data, addressing #28.

This PR is nearly identical to #18, but includes documentation updates and uses the terminology "weight" instead of "count", as the value may not necessarily be an integer. Feel free to close if you have a different preferred terminology. In any case, there appears to be sustained interest in this feature, including from Vega users.

