### PR TITLE
Fix size checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ And here is a density contour plot showing the relationship between the weight a
 If you use NPM, `npm install d3-contour`. Otherwise, download the [latest release](https://github.com/d3/d3-contour/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-contour.v1.min.js) or as part of [D3 4.0](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
 
 ```html
-<script src="https://d3js.org/d3-contour.v1.min.js"></script>
+<script src="https://d3js.org/d3-array.v2.min.js"></script>
+<script src="https://d3js.org/d3-contour.v2.min.js"></script>
 <script>
 
 // Populate a grid of n×m values where -2 ≤ x ≤ 2 and -2 ≤ y ≤ 1.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "d3-contour",
-  "version": "2.0.0-rc.1",
-  "publishConfig": {
-    "tag": "next"
-  },
+  "version": "2.0.0",
   "description": "Compute contour polygons using marching squares.",
   "keywords": [
     "d3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "d3-contour",
-  "version": "1.3.2",
+  "version": "2.0.0-rc.1",
+  "publishConfig": {
+    "tag": "next"
+  },
   "description": "Compute contour polygons using marching squares.",
   "keywords": [
     "d3",
@@ -40,6 +43,6 @@
     "tape": "4"
   },
   "dependencies": {
-    "d3-array": "^1.1.1 - 2"
+    "d3-array": "2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "tape": "4"
   },
   "dependencies": {
-    "d3-array": "^1.1.1"
+    "d3-array": "^1.1.1 - 2"
   }
 }

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,5 +1,1 @@
-export default function(x) {
-  return function() {
-    return x;
-  };
-}
+export default x => () => x;

--- a/src/contours.js
+++ b/src/contours.js
@@ -186,8 +186,8 @@ export default function() {
 
   contours.size = function(_) {
     if (!arguments.length) return [dx, dy];
-    var _0 = Math.ceil(_[0]), _1 = Math.ceil(_[1]);
-    if (!(_0 > 0) || !(_1 > 0)) throw new Error("invalid size");
+    var _0 = Math.floor(_[0]), _1 = Math.floor(_[1]);
+    if (!(_0 >= 0 && _1 >= 0)) throw new Error("invalid size");
     return dx = _0, dy = _1, contours;
   };
 

--- a/src/density.js
+++ b/src/density.js
@@ -108,8 +108,8 @@ export default function() {
 
   density.size = function(_) {
     if (!arguments.length) return [dx, dy];
-    var _0 = Math.ceil(_[0]), _1 = Math.ceil(_[1]);
-    if (!(_0 >= 0) && !(_0 >= 0)) throw new Error("invalid size");
+    var _0 = +_[0], _1 = +_[1];
+    if (!(_0 >= 0 && _1 >= 0)) throw new Error("invalid size");
     return dx = _0, dy = _1, resize();
   };
 

--- a/test/contours-test.js
+++ b/test/contours-test.js
@@ -206,3 +206,16 @@ tape("contours(values) returns the expected result for a multipolygon with holes
   ]);
   test.end();
 });
+
+tape("contours.size(…) validates the specified size", function(test) {
+  test.deepEqual(d3.contours().size([1, 2]).size(), [1, 2]);
+  test.deepEqual(d3.contours().size([0, 0]).size(), [0, 0]);
+  test.deepEqual(d3.contours().size([1.5, 2.5]).size(), [1, 2]);
+  try {
+    d3.contours().size([0, -1]);
+    test.fail();
+  } catch (error) {
+    test.equal(error.message, "invalid size");
+  }
+  test.end();
+});

--- a/test/density-test.js
+++ b/test/density-test.js
@@ -1,0 +1,15 @@
+var d3 = require("../"),
+    tape = require("tape");
+
+tape("density.size(…) validates the specified size", function(test) {
+  test.deepEqual(d3.contourDensity().size([1, 2]).size(), [1, 2]);
+  test.deepEqual(d3.contourDensity().size([0, 0]).size(), [0, 0]);
+  test.deepEqual(d3.contourDensity().size([1.5, 2.5]).size(), [1.5, 2.5]);
+  try {
+    d3.contourDensity().size([0, -1]);
+    test.fail();
+  } catch (error) {
+    test.equal(error.message, "invalid size");
+  }
+  test.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,10 +169,10 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-d3-array@^1.1.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+d3-array@2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
 debug@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
Fixes #42. @jheer, I invited you to the team so you can review. Thanks! Also:

* *density*.size doesn’t need to be an integer
* *contours*.size should use Math.floor for parity with JavaScript (e.g., new Array(*length*))
