### PR TITLE
Speed up stitching

### DIFF
--- a/src/contours.js
+++ b/src/contours.js
@@ -131,7 +131,8 @@ export default function() {
             f.ring.push(end);
             callback(f.ring);
           } else {
-            fragmentByStart[f.start] = fragmentByEnd[g.end] = {start: f.start, end: g.end, ring: f.ring.concat(g.ring)};
+            Array.prototype.push.apply(f.ring, g.ring);
+            fragmentByStart[f.start] = fragmentByEnd[g.end] = {start: f.start, end: g.end, ring: f.ring};
           }
         } else {
           delete fragmentByEnd[f.end];
@@ -146,7 +147,8 @@ export default function() {
             f.ring.push(end);
             callback(f.ring);
           } else {
-            fragmentByStart[g.start] = fragmentByEnd[f.end] = {start: g.start, end: f.end, ring: g.ring.concat(f.ring)};
+            Array.prototype.push.apply(g.ring, f.ring);
+            fragmentByStart[g.start] = fragmentByEnd[f.end] = {start: g.start, end: f.end, ring: g.ring};
           }
         } else {
           delete fragmentByStart[f.start];


### PR DESCRIPTION
As described in #44, this replaces a costly `concat` call with `Array.prototype.push` which due to its non-copying semantics is generally faster in all JS engines.

As far as I can see, the `concat` is also not necessary in these two places, the ring arrays can be safely reused and needs not to be copied. But I'm not 100% sure on that maybe I missed something.