### PR TITLE
round tick values

### DIFF
--- a/src/contours.js
+++ b/src/contours.js
@@ -1,4 +1,4 @@
-import {extent, thresholdSturges, tickStep, range} from "d3-array";
+import {extent, thresholdSturges, ticks, tickStep} from "d3-array";
 import {slice} from "./array.js";
 import ascending from "./ascending.js";
 import area from "./area.js";
@@ -36,16 +36,13 @@ export default function() {
 
     // Convert number of thresholds into uniform thresholds.
     if (!Array.isArray(tz)) {
-      var domain = extent(values), start = domain[0], stop = domain[1];
-      tz = tickStep(start, stop, tz);
-      tz = range(Math.floor(start / tz) * tz, Math.floor(stop / tz) * tz, tz);
+      const e = extent(values), ts = tickStep(e[0], e[1], tz);
+      tz = ticks(Math.floor(e[0] / ts) * ts, Math.floor(e[1] / ts - 1) * ts, tz);
     } else {
       tz = tz.slice().sort(ascending);
     }
 
-    return tz.map(function(value) {
-      return contour(values, value);
-    });
+    return tz.map(value => contour(values, value));
   }
 
   // Accumulate, smooth contour rings, assign holes to exterior rings.

--- a/test/contours-test.js
+++ b/test/contours-test.js
@@ -206,3 +206,19 @@ it("contours.size(…) validates the specified size", () => {
   assert.deepStrictEqual(contours().size([1.5, 2.5]).size(), [1, 2]);
   assert.throws(() => void contours().size([0, -1]), /invalid size/);
 });
+
+it("contours(values) returns the expected thresholds", () => {
+  const c = contours().size([10, 10]).thresholds(20);
+  assert.deepStrictEqual(c([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 1, 1, 0, 1, 1, 1, 0, 0,
+    0, 1, 0, 1, 0, 1, 0, 1, 0, 0,
+    0, 1, 1, 1, 0, 1, 1, 1, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+  ]).map(d => d.value), [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]);
+});


### PR DESCRIPTION
(upgrade to https://github.com/d3/d3-array/commit/04cf783bd715cae89303173d50a28fda38c24a9b)

before:
<img width="761" alt="Capture d’écran 2020-09-01 à 10 19 48" src="https://user-images.githubusercontent.com/7001/91826891-77c8d780-ec3e-11ea-9467-7d20c43c6eee.png">


after:


<img width="629" alt="Capture d’écran 2020-09-01 à 10 50 48" src="https://user-images.githubusercontent.com/7001/91828909-09394900-ec41-11ea-88d8-0fbc5021c17d.png">
