### PR TITLE
respect thresholds passed to contourDensity

### DIFF
--- a/src/density.js
+++ b/src/density.js
@@ -61,7 +61,10 @@ export default function() {
     var tz = threshold(values0);
 
     // Convert number of thresholds into uniform thresholds.
-    if (!Array.isArray(tz)) {
+    if (Array.isArray(tz)) {
+      const pow4k = Math.pow(2, 2 * k);
+      tz = tz.map(d => d * pow4k);
+    } else {
       var stop = max(values0);
       tz = tickStep(0, stop, tz);
       tz = range(0, Math.floor(stop / tz) * tz, tz);

--- a/test/density-test.js
+++ b/test/density-test.js
@@ -16,7 +16,7 @@ it("contourDensity(data) returns the expected result for empty data", () => {
 });
 
 it("contourDensity(data) returns contours centered on a point", () => {
-  const c = contourDensity().thresholds([0.0001, 0.001]);
+  const c = contourDensity().thresholds([0.00001, 0.0001]);
   for (const p of [[100, 100], [100.5, 102]]) {
     const contour = c([p]);
     assert.strictEqual(contour.length, 2);
@@ -26,4 +26,24 @@ it("contourDensity(data) returns contours centered on a point", () => {
       assertInDelta(a[1], p[1], 0.1);
     }
   }
+});
+
+it("contourDensity.thresholds(values[])(data) returns contours for the given values", () => {
+  const points = [[1, 0], [0, 1], [1, 1]];
+  const c = contourDensity();
+  const c1 = c(points);
+  const values1 = c1.map(d => d.value);
+  const c2 = c.thresholds(values1)(points);
+  const values2 = c2.map(d => d.value);
+  assert.deepStrictEqual(values1, values2);
+});
+
+it("contourDensity.thresholds(values[])(data) returns contours for the given values at a different cellSize", () => {
+  const points = [[1, 0], [0, 1], [1, 1]];
+  const c = contourDensity().cellSize(16);
+  const c1 = c(points);
+  const values1 = c1.map(d => d.value);
+  const c2 = c.thresholds(values1)(points);
+  const values2 = c2.map(d => d.value);
+  assert.deepStrictEqual(values1, values2);
 });


### PR DESCRIPTION
When passing thresholds([0.5]) to contourDensity, one would expect the returned thresholds to be 0.5, but instead we get 0.5 * 2^-2k = 1/32 (with the default cellSize k=2).

This fixes the logic so that the thresholds are respected. Unfortunately it is a breaking change or any user who has manually set those thresholds.