### PR TITLE
Support a mean aggregation strategy

### DIFF
--- a/src/density.js
+++ b/src/density.js
@@ -50,10 +50,10 @@ export default function() {
         values[x0 + (y0 + 1) * n] += (1 - xt) * yt * wi;
 
         if(aggregation === 'MEAN') {
-          valueCounts[x0 + y0 * n] += 1;
-          valueCounts[x0 + 1 + y0 * n] += 1;
-          valueCounts[x0 + 1 + (y0 + 1) * n] += 1;
-          valueCounts[x0 + (y0 + 1) * n] += 1;
+          valueCounts[x0 + y0 * n] += (1 - xt) * (1 - yt);
+          valueCounts[x0 + 1 + y0 * n] += xt * (1 - yt);
+          valueCounts[x0 + 1 + (y0 + 1) * n] += xt * yt;
+          valueCounts[x0 + (y0 + 1) * n] += (1 - xt) * yt;
         }
       }
     }

--- a/test/density-test.js
+++ b/test/density-test.js
@@ -87,6 +87,35 @@ it("contourDensity(data) returns nice default thresholds", async () => {
   assert.deepStrictEqual(contour.map(c => c.value), ticks(0.0002, 0.0059, 30));
 });
 
+it("contourDensity(data) supports a MEAN aggregation strategy", async () => {
+  const faithful = await tsv("data/faithful.tsv", autoType);
+
+  const width = 960,
+        height = 500,
+        marginTop = 20,
+        marginRight = 30,
+        marginBottom = 30,
+        marginLeft = 40;
+
+  const x = scaleLinear()
+      .domain(extent(faithful, d => d.waiting)).nice()
+      .rangeRound([marginLeft, width - marginRight]);
+
+  const y = scaleLinear()
+      .domain(extent(faithful, d => d.eruptions)).nice()
+      .rangeRound([height - marginBottom, marginTop]);
+
+  const contour = contourDensity()
+      .x(d => x(d.waiting))
+      .y(d => y(d.eruptions))
+      .size([width, height])
+      .bandwidth(30)
+      .aggregation('MEAN')
+    (faithful);
+
+  assert.deepStrictEqual(contour.map(c => c.value), ticks(0.0002, 0.0044, 22));
+});
+
 it("contourDensity.contours(data) preserves the specified threshold exactly", async () => {
   const faithful = await tsv("data/faithful.tsv", autoType);
 


### PR DESCRIPTION
Currently, the implementation always takes the sum. However we might want to use a different aggregation strategy, in particular, mean. This is possible with the DeckGL ContourLayer, for example: https://deck.gl/docs/api-reference/aggregation-layers/contour-layer#aggregation

This PR adds a `.aggregation('MEAN')` option to specify this as an aggregation strategy.